### PR TITLE
Bug/61190 titel immer ag marktplatz

### DIFF
--- a/src/modules/app/app.component.ts
+++ b/src/modules/app/app.component.ts
@@ -23,9 +23,9 @@ export class AppComponent implements OnInit {
       .pipe(
         filter(event => event instanceof NavigationEnd),
         map(() => {
-          const child = this.activatedRoute.firstChild?.firstChild;
-          if (child?.snapshot.data['title']) {
-            return child.snapshot.data['title'];
+          const nestedRoute = this.activatedRoute.firstChild?.firstChild;
+          if (nestedRoute?.snapshot.data['title']) {
+            return nestedRoute.snapshot.data['title'];
           }
           return appTitle;
         })

--- a/src/modules/app/app.component.ts
+++ b/src/modules/app/app.component.ts
@@ -23,7 +23,7 @@ export class AppComponent implements OnInit {
       .pipe(
         filter(event => event instanceof NavigationEnd),
         map(() => {
-          const child = this.activatedRoute.firstChild;
+          const child = this.activatedRoute.firstChild?.firstChild;
           if (child?.snapshot.data['title']) {
             return child.snapshot.data['title'];
           }


### PR DESCRIPTION
Nesting level der Routen ist jetzt eins hoeher, durch die leere "Parent Route" die den AuthGuard aktiviert. Wir haben den Titel von dieser Parent Route geholt, daher der Fallback auf Default "AgriGaia Marktplatz". Jetzt wird er wieder korrekt von der Child Route geholt.